### PR TITLE
Cache certs

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -26,6 +27,13 @@ const (
 		x509.KeyUsageCertSign |
 		x509.KeyUsageCRLSign
 	leafUsage = caUsage
+
+	maxCacheSize = 1000
+)
+
+var (
+	certCache = make(map[*tls.Certificate]map[string]*tls.Certificate)
+	certMutex sync.RWMutex
 )
 
 // GenerateCA generates a CA cert and key pair.
@@ -67,6 +75,10 @@ func GenerateCA(name string) (certPEM, keyPEM []byte, err error) {
 
 // GenerateCert generates a leaf cert from ca.
 func GenerateCert(ca *tls.Certificate, hosts ...string) (*tls.Certificate, error) {
+	if cert := getCachedCert(ca, hosts); cert != nil {
+		return cert, nil
+	}
+
 	now := time.Now().Add(-1 * time.Hour).UTC()
 	if !ca.Leaf.IsCA {
 		return nil, errors.New("CA cert is not a CA")
@@ -106,9 +118,47 @@ func GenerateCert(ca *tls.Certificate, hosts ...string) (*tls.Certificate, error
 	cert.Certificate = append(cert.Certificate, x)
 	cert.PrivateKey = key
 	cert.Leaf, _ = x509.ParseCertificate(x)
+	cacheCert(ca, hosts, cert)
 	return cert, nil
 }
 
 func genKeyPair() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+}
+
+func getCachedCert(ca *tls.Certificate, hosts []string) *tls.Certificate {
+	certMutex.RLock()
+	defer certMutex.RUnlock()
+
+	// Don't try to deal with multiple hosts (dynamically generated
+	// mitm certs only have one host)
+	if len(hosts) != 1 {
+		return nil
+	}
+	if certCache[ca] == nil {
+		return nil
+	}
+	h := hosts[0]
+	cert := certCache[ca][h]
+	if cert == nil {
+		return nil
+	} else if cert.Leaf.NotAfter.Before(time.Now()) {
+		certCache[ca][h] = nil
+		return nil
+	} else {
+		return cert
+	}
+}
+
+func cacheCert(ca *tls.Certificate, hosts []string, cert *tls.Certificate) {
+	certMutex.Lock()
+	defer certMutex.Unlock()
+
+	if len(hosts) != 1 {
+		return
+	}
+	if certCache[ca] == nil || len(certCache[ca]) > maxCacheSize {
+		certCache[ca] = make(map[string]*tls.Certificate)
+	}
+	certCache[ca][hosts[0]] = cert
 }


### PR DESCRIPTION
This got nixed in the big refactor, but it seems worthwhile (cert
generation takes 80-100ms on my machine).

@rainforestapp/core @ukd1
