### PR TITLE
Change key/signature algorithms

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -83,7 +83,7 @@ func GenerateCert(ca *tls.Certificate, hosts ...string) (*tls.Certificate, error
 		NotAfter:              now.Add(leafMaxAge),
 		KeyUsage:              leafUsage,
 		BasicConstraintsValid: true,
-		SignatureAlgorithm:    x509.ECDSAWithSHA512,
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
 	}
 
 	for _, h := range hosts {
@@ -110,5 +110,5 @@ func GenerateCert(ca *tls.Certificate, hosts ...string) (*tls.Certificate, error
 }
 
 func genKeyPair() (*ecdsa.PrivateKey, error) {
-	return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 }


### PR DESCRIPTION
Chrome 48 no longer supports P521 as a key on not-Android:
- https://boringssl.googlesource.com/boringssl/+/4298d773

or ECDSAWithSHA512 signatures. This was determined imperially and I
couldn't determine the root cause. Potentially related:
- https://bugzilla.mozilla.org/show_bug.cgi?id=1129083
- http://crypto.stackexchange.com/questions/11563/signature-algorithm-sha-1-2-with-ecdsa
